### PR TITLE
feat: remove global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ const mutex = mortice('my-lock', {
    // control how many read operations are executed concurrently (default: Infinity)
   concurrency: 5,
 
-  // the global object (for use with webworkify and similar) (default: global)
-  global: window,
-
   // by default the the lock will be held on the main thread, set this to true if the
   // a lock should reside on each worker (default: false)
   singleProcess: false

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -9,6 +9,7 @@ const {
   MASTER_GRANT_WRITE_LOCK
 } = require('./constants')
 const observer = require('observable-webworkers')
+const globalThis = require('globalthis')()
 
 const handleWorkerLockRequest = (emitter, masterEvent, requestType, releaseType, grantType) => {
   return (worker, event) => {
@@ -55,11 +56,11 @@ const handleWorkerLockRequest = (emitter, masterEvent, requestType, releaseType,
   }
 }
 
-const makeWorkerLockRequest = (global, name, requestType, grantType, releaseType) => {
+const makeWorkerLockRequest = (name, requestType, grantType, releaseType) => {
   return (fn) => {
     const id = shortid.generate()
 
-    global.postMessage({
+    globalThis.postMessage({
       type: requestType,
       identifier: id,
       name
@@ -77,7 +78,7 @@ const makeWorkerLockRequest = (global, name, requestType, grantType, releaseType
         }
 
         if (responseEvent && responseEvent.type === grantType && responseEvent.identifier === id) {
-          global.removeEventListener('message', listener)
+          globalThis.removeEventListener('message', listener)
 
           let error
 
@@ -86,7 +87,7 @@ const makeWorkerLockRequest = (global, name, requestType, grantType, releaseType
               error = err
             })
             .then((result) => {
-              global.postMessage({
+              globalThis.postMessage({
                 type: releaseType,
                 identifier: id,
                 name
@@ -101,19 +102,18 @@ const makeWorkerLockRequest = (global, name, requestType, grantType, releaseType
         }
       }
 
-      global.addEventListener('message', listener)
+      globalThis.addEventListener('message', listener)
     })
   }
 }
 
 const defaultOptions = {
-  global: global,
   singleProcess: false
 }
 
 module.exports = (options) => {
   options = Object.assign({}, defaultOptions, options)
-  const isMaster = !!options.global.document || options.singleProcess
+  const isMaster = !!globalThis.document || options.singleProcess
 
   if (isMaster) {
     const emitter = new EventEmitter()
@@ -126,7 +126,7 @@ module.exports = (options) => {
 
   return {
     isWorker: true,
-    readLock: (name, options) => makeWorkerLockRequest(options.global, name, WORKER_REQUEST_READ_LOCK, MASTER_GRANT_READ_LOCK, WORKER_RELEASE_READ_LOCK),
-    writeLock: (name, options) => makeWorkerLockRequest(options.global, name, WORKER_REQUEST_WRITE_LOCK, MASTER_GRANT_WRITE_LOCK, WORKER_RELEASE_WRITE_LOCK)
+    readLock: (name, options) => makeWorkerLockRequest(name, WORKER_REQUEST_READ_LOCK, MASTER_GRANT_READ_LOCK, WORKER_RELEASE_READ_LOCK),
+    writeLock: (name, options) => makeWorkerLockRequest(name, WORKER_REQUEST_WRITE_LOCK, MASTER_GRANT_WRITE_LOCK, WORKER_RELEASE_WRITE_LOCK)
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const browser = require('./browser')
 const Queue = require('p-queue')
 const { timeout } = require('promise-timeout')
 const observe = require('observable-webworkers')
+const globalThis = require('globalthis')()
 
 const mutexes = {}
 let implementation
@@ -67,7 +68,6 @@ const createMutex = (name, options) => {
 const defaultOptions = {
   concurrency: Infinity,
   timeout: 84600000,
-  global: global,
   singleProcess: false
 }
 
@@ -110,7 +110,7 @@ module.exports = (name, options) => {
 }
 
 module.exports.Worker = function (script, Impl) {
-  Impl = Impl || global.Worker
+  Impl = Impl || globalThis.Worker
   let worker
 
   try {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "concurrency": 1
   },
   "dependencies": {
+    "globalthis": "^1.0.0",
     "observable-webworkers": "^1.0.0",
     "p-queue": "^5.0.0",
     "promise-timeout": "^1.3.0",

--- a/test/fixtures/worker-single-thread.js
+++ b/test/fixtures/worker-single-thread.js
@@ -2,7 +2,6 @@ const mortice = require('../../')
 
 module.exports = (self) => {
   const mutex = mortice({
-    global: self,
     singleProcess: true
   })
 

--- a/test/fixtures/worker.js
+++ b/test/fixtures/worker.js
@@ -1,9 +1,7 @@
 const mortice = require('../../')
 
 module.exports = (self) => {
-  const mutex = mortice({
-    global: self
-  })
+  const mutex = mortice()
 
   mutex.writeLock(() => {
     return new Promise((resolve) => {


### PR DESCRIPTION
BREAKING CHANGE: no longer supports passing a `global` ref as an option

Uses the [globalThis](https://www.npmjs.com/package/globalthis) module to get the correct global context.