### PR TITLE
Introduce managed locks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ const defaultOptions = {
   singleProcess: false
 }
 
-module.exports = (name, options) => {
+const defaultCreateMutex = (name, options) => {
   if (!options) {
     options = {}
   }
@@ -135,6 +135,31 @@ module.exports = (name, options) => {
   }
 
   return mutexes[name]
+}
+
+module.exports = defaultCreateMutex
+
+const managedLockOfType = async function (lockType, name, options) {
+  const mutex = defaultCreateMutex(name, options)
+
+  const mutexRelease = await mutex[lockType]()
+  return async () => {
+    await mutexRelease()
+    await new Promise(resolve => setTimeout(resolve, 0)) // queue timeout takes another tick to complete
+    if (mutex.isIdle()) {
+      delete mutexes[name]
+    }
+  }
+}
+
+module.exports.managed = {
+  readLock: async function (name, options) {
+    return managedLockOfType('readLock', name, options)
+  },
+
+  writeLock: function(name, options) {
+    return managedLockOfType('writeLock', name, options)
+  }
 }
 
 module.exports.Worker = function (script, Impl) {

--- a/test/managed.test.js
+++ b/test/managed.test.js
@@ -1,0 +1,31 @@
+import test from 'ava'
+
+const mortice = require('../')
+
+test('should manage returned read mutexes', async (t) => {
+  const name = 'aLock'
+
+  const readLockRelease = await mortice.managed.readLock(name)
+  const mutexAtFirstAccess = mortice(name);
+
+  await readLockRelease();
+
+  await mortice.managed.readLock(name)
+  const mutexAtSecondAccess = mortice(name);
+
+  t.true(mutexAtFirstAccess !== mutexAtSecondAccess)
+})
+
+test('should manage returned write mutexes', async (t) => {
+  const name = 'bLock'
+
+  const readLockRelease = await mortice.managed.writeLock(name)
+  const mutexAtFirstAccess = mortice(name);
+
+  await readLockRelease();
+
+  await mortice.managed.readLock(name)
+  const mutexAtSecondAccess = mortice(name);
+
+  t.true(mutexAtFirstAccess !== mutexAtSecondAccess)
+})


### PR DESCRIPTION
In a long-running application with dynamic keys it is possible to fill
the mutexes object up with stale locks. Eventually this will become a
significant use of memory (some basic testing showed one million locks
take around 650MB under node 12).

This patch introduces mortice.managed, which exposes read and write
locks. The mutex objects backing these locks will be automatically
removed when the last lock is released, freeing up the memory.