### PR TITLE
fix: switch to BroadcastChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repo and examine the changes made.
 
 ## Example
 
-```javascript
+```ts
 import mortice from 'mortice'
 import delay from 'delay'
 
@@ -87,41 +87,6 @@ write 1
 read 3
 ```
 
-## Browser
-
-Because there's no global way to eavesdrop on messages sent by Web Workers,
-please pass all created Web Workers to the [`observable-webworkers`](https://npmjs.org/package/observable-webworkers)
-module:
-
-```javascript
-// main.js
-import mortice from 'mortice'
-import observe from 'observable-webworkers'
-
-// create our lock on the main thread, it will be held here
-const mutex = mortice()
-
-const worker = new Worker('worker.js')
-
-observe(worker)
-```
-
-```javascript
-// worker.js
-import mortice from 'mortice'
-import delay from 'delay'
-
-const mutex = mortice()
-
-let release = await mutex.readLock()
-// read something
-release()
-
-release = await mutex.writeLock()
-// write something
-release()
-```
-
 ## Clean up
 
 Mutexes are stored globally reference by name, this is so you can obtain the
@@ -130,7 +95,7 @@ same lock from different contexts, including workers.
 When a mutex is no longer required, the `.finalize` function should be called
 to remove any internal references to it.
 
-```javascript
+```ts
 import mortice from 'mortice'
 
 const mutex = mortice()

--- a/package.json
+++ b/package.json
@@ -159,8 +159,10 @@
     "wherearewe": "^2.0.1"
   },
   "browser": {
-    "cluster": false,
+    "node:cluster": false,
+    "node:worker_threads": false,
     "./dist/src/node.js": "./dist/src/browser.js",
-    "./src/node.js": "./src/browser.js"
+    "./src/node.js": "./src/browser.js",
+    "./test/fixtures/worker-post-message.ts": "./test/fixtures/worker-post-message.browser.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -163,6 +163,6 @@
     "node:worker_threads": false,
     "./dist/src/node.js": "./dist/src/browser.js",
     "./src/node.js": "./src/browser.js",
-    "./test/fixtures/worker-post-message.ts": "./test/fixtures/worker-post-message.browser.ts"
+    "./test/fixtures/worker-post-message.js": "./test/fixtures/worker-post-message.browser.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -148,14 +148,14 @@
   "dependencies": {
     "abort-error": "^1.0.0",
     "it-queue": "^1.1.0",
-    "main-event": "^1.0.0",
-    "observable-webworkers": "^2.0.1"
+    "main-event": "^1.0.0"
   },
   "devDependencies": {
     "aegir": "^47.0.15",
     "delay": "^6.0.0",
     "esbuild": "^0.25.4",
     "execa": "^9.5.3",
+    "observable-webworkers": "^2.0.1",
     "wherearewe": "^2.0.1"
   },
   "browser": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,3 +1,4 @@
+import { TypedEventEmitter } from 'main-event'
 import {
   WORKER_REQUEST_READ_LOCK,
   WORKER_RELEASE_READ_LOCK,
@@ -12,11 +13,11 @@ import {
   BROADCAST_CHANNEL_NAME,
   defaultOptions
 } from './constants.js'
-import type { Mortice, MorticeOptions } from './index.js'
-import type { MorticeEvents} from './mortice.js'
-import { TypedEventEmitter, type TypedEventTarget } from 'main-event'
-import { MorticeChannelWorker } from './workers/channel.ts'
 import { handleChannelWorkerLockRequest } from './main/channel.ts'
+import { MorticeChannelWorker } from './workers/channel.ts'
+import type { Mortice, MorticeOptions } from './index.js'
+import type { MorticeEvents } from './mortice.js'
+import type { TypedEventTarget } from 'main-event'
 
 export default (options: Required<MorticeOptions>): Mortice | TypedEventTarget<MorticeEvents> => {
   options = Object.assign({}, defaultOptions, options)

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,3 @@
-import observer from 'observable-webworkers'
 import {
   WORKER_REQUEST_READ_LOCK,
   WORKER_RELEASE_READ_LOCK,
@@ -10,216 +9,26 @@ import {
   WORKER_ABORT_WRITE_LOCK_REQUEST,
   MASTER_READ_LOCK_ERROR,
   MASTER_WRITE_LOCK_ERROR,
-  WORKER_FINALIZE
+  BROADCAST_CHANNEL_NAME,
+  defaultOptions
 } from './constants.js'
-import { nanoid } from './utils.js'
-import type { Mortice, MorticeOptions, Release } from './index.js'
-import type { AbortRequestType, FinalizeEventData, RequestEventData, RequestType } from './mortice.js'
-import type { AbortOptions } from 'abort-error'
+import type { Mortice, MorticeOptions } from './index.js'
+import type { MorticeEvents} from './mortice.js'
+import { TypedEventEmitter, type TypedEventTarget } from 'main-event'
+import { MorticeChannelWorker } from './workers/channel.ts'
+import { handleChannelWorkerLockRequest } from './main/channel.ts'
 
-const handleWorkerLockRequest = (emitter: EventTarget, masterEvent: RequestType, abortMasterEvent: AbortRequestType, requestType: string, abortType: string, errorType: string, releaseType: string, grantType: string) => {
-  return (worker: Worker, event: MessageEvent) => {
-    if (event.data == null) {
-      return
-    }
-
-    const requestEvent = {
-      type: event.data.type,
-      name: event.data.name,
-      identifier: event.data.identifier
-    }
-
-    // worker is requesting lock
-    if (requestEvent.type === requestType) {
-      emitter.dispatchEvent(new MessageEvent<RequestEventData>(masterEvent, {
-        data: {
-          name: requestEvent.name,
-          identifier: requestEvent.identifier,
-          handler: async (): Promise<void> => {
-            // grant lock to worker
-            worker.postMessage({
-              type: grantType,
-              name: requestEvent.name,
-              identifier: requestEvent.identifier
-            })
-
-            // wait for worker to finish
-            await new Promise<void>((resolve) => {
-              const releaseEventListener = (event: MessageEvent): void => {
-                if (event?.data == null) {
-                  return
-                }
-
-                const releaseEvent = {
-                  type: event.data.type,
-                  name: event.data.name,
-                  identifier: event.data.identifier
-                }
-
-                if (releaseEvent.type === releaseType && releaseEvent.identifier === requestEvent.identifier) {
-                  worker.removeEventListener('message', releaseEventListener)
-                  resolve()
-                }
-              }
-
-              worker.addEventListener('message', releaseEventListener)
-            })
-          },
-          onError: (err: Error) => {
-            // send error to worker
-            worker.postMessage({
-              type: errorType,
-              name: requestEvent.name,
-              identifier: requestEvent.identifier,
-              error: {
-                message: err.message,
-                name: err.name,
-                stack: err.stack
-              }
-            })
-          }
-        }
-      }))
-    }
-
-    // worker is no longer interested in requesting the lock
-    if (requestEvent.type === abortType) {
-      emitter.dispatchEvent(new MessageEvent(abortMasterEvent, {
-        data: {
-          name: requestEvent.name,
-          identifier: requestEvent.identifier
-        }
-      }))
-    }
-
-    // worker is done with lock
-    if (requestEvent.type === WORKER_FINALIZE) {
-      emitter.dispatchEvent(new MessageEvent<FinalizeEventData>('finalizeRequest', {
-        data: {
-          name: requestEvent.name
-        }
-      }))
-    }
-  }
-}
-
-const defaultOptions = {
-  singleProcess: false
-}
-
-class MorticeWorker implements Mortice {
-  private name: string
-
-  constructor (name: string) {
-    this.name = name
-  }
-
-  readLock (options?: AbortOptions): Promise<Release> {
-    return this.sendRequest(
-      WORKER_REQUEST_READ_LOCK,
-      WORKER_ABORT_READ_LOCK_REQUEST,
-      MASTER_GRANT_READ_LOCK,
-      MASTER_READ_LOCK_ERROR,
-      WORKER_RELEASE_READ_LOCK,
-      options
-    )
-  }
-
-  writeLock (options?: AbortOptions): Promise<Release> {
-    return this.sendRequest(
-      WORKER_REQUEST_WRITE_LOCK,
-      WORKER_ABORT_WRITE_LOCK_REQUEST,
-      MASTER_GRANT_WRITE_LOCK,
-      MASTER_WRITE_LOCK_ERROR,
-      WORKER_RELEASE_WRITE_LOCK,
-      options
-    )
-  }
-
-  finalize (): void {
-    const id = nanoid()
-
-    globalThis.postMessage({
-      type: WORKER_FINALIZE,
-      identifier: id,
-      name: this.name
-    })
-  }
-
-  private async sendRequest (requestType: string, abortType: string, grantType: string, errorType: string, releaseType: string, options?: AbortOptions): Promise<Release> {
-    options?.signal?.throwIfAborted()
-    const id = nanoid()
-
-    globalThis.postMessage({
-      type: requestType,
-      identifier: id,
-      name: this.name
-    })
-
-    return new Promise<Release>((resolve, reject) => {
-      const abortListener = (): void => {
-        globalThis.postMessage({
-          type: abortType,
-          identifier: id,
-          name: this.name
-        })
-      }
-
-      options?.signal?.addEventListener('abort', abortListener, {
-        once: true
-      })
-
-      const listener = (event: MessageEvent): void => {
-        if (event.data?.identifier !== id) {
-          return
-        }
-
-        if (event.data?.type === grantType) {
-          globalThis.removeEventListener('message', listener)
-          options?.signal?.removeEventListener('abort', abortListener)
-
-          // lock granted
-          resolve(() => {
-            // release lock
-            globalThis.postMessage({
-              type: releaseType,
-              identifier: id,
-              name: this.name
-            })
-          })
-        }
-
-        if (event.data.type === errorType) {
-          globalThis.removeEventListener('message', listener)
-          options?.signal?.removeEventListener('abort', abortListener)
-
-          // error while waiting for grant of lock
-          const err = new Error()
-
-          if (event.data.error != null) {
-            err.message = event.data.error.message
-            err.name = event.data.error.name
-            err.stack = event.data.error.stack
-          }
-
-          reject(err)
-        }
-      }
-
-      globalThis.addEventListener('message', listener)
-    })
-  }
-}
-
-export default (options: Required<MorticeOptions>): Mortice | EventTarget => {
+export default (options: Required<MorticeOptions>): Mortice | TypedEventTarget<MorticeEvents> => {
   options = Object.assign({}, defaultOptions, options)
   const isPrimary = Boolean(globalThis.document) || options.singleProcess
 
   if (isPrimary) {
-    const emitter = new EventTarget()
+    const channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME)
+    const emitter = new TypedEventEmitter<MorticeEvents>()
 
-    observer.addEventListener('message', handleWorkerLockRequest(
+    channel.addEventListener('message', handleChannelWorkerLockRequest(
       emitter,
+      channel,
       'requestReadLock',
       'abortReadLockRequest',
       WORKER_REQUEST_READ_LOCK,
@@ -228,8 +37,9 @@ export default (options: Required<MorticeOptions>): Mortice | EventTarget => {
       WORKER_RELEASE_READ_LOCK,
       MASTER_GRANT_READ_LOCK
     ))
-    observer.addEventListener('message', handleWorkerLockRequest(
+    channel.addEventListener('message', handleChannelWorkerLockRequest(
       emitter,
+      channel,
       'requestWriteLock',
       'abortWriteLockRequest',
       WORKER_REQUEST_WRITE_LOCK,
@@ -242,5 +52,5 @@ export default (options: Required<MorticeOptions>): Mortice | EventTarget => {
     return emitter
   }
 
-  return new MorticeWorker(options.name)
+  return new MorticeChannelWorker(options.name)
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,9 @@ export const MASTER_GRANT_WRITE_LOCK = 'lock:master:grant-write'
 export const MASTER_WRITE_LOCK_ERROR = 'lock:master:error-write'
 
 export const WORKER_FINALIZE = 'lock:worker:finalize'
+
+export const BROADCAST_CHANNEL_NAME = 'mortice'
+
+export const defaultOptions = {
+  singleProcess: false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  *
  * @example
  *
- * ```javascript
+ * ```ts
  * import mortice from 'mortice'
  * import delay from 'delay'
  *
@@ -64,41 +64,6 @@
  *     write 1
  *     read 3
  *
- * ## Browser
- *
- * Because there's no global way to eavesdrop on messages sent by Web Workers,
- * please pass all created Web Workers to the [`observable-webworkers`](https://npmjs.org/package/observable-webworkers)
- * module:
- *
- * ```javascript
- * // main.js
- * import mortice from 'mortice'
- * import observe from 'observable-webworkers'
- *
- * // create our lock on the main thread, it will be held here
- * const mutex = mortice()
- *
- * const worker = new Worker('worker.js')
- *
- * observe(worker)
- * ```
- *
- * ```javascript
- * // worker.js
- * import mortice from 'mortice'
- * import delay from 'delay'
- *
- * const mutex = mortice()
- *
- * let release = await mutex.readLock()
- * // read something
- * release()
- *
- * release = await mutex.writeLock()
- * // write something
- * release()
- * ```
- *
  * ## Clean up
  *
  * Mutexes are stored globally reference by name, this is so you can obtain the
@@ -107,7 +72,7 @@
  * When a mutex is no longer required, the `.finalize` function should be called
  * to remove any internal references to it.
  *
- * ```javascript
+ * ```ts
  * import mortice from 'mortice'
  *
  * const mutex = mortice()

--- a/src/main/channel.ts
+++ b/src/main/channel.ts
@@ -1,8 +1,8 @@
 import {
   WORKER_FINALIZE
 } from '../constants.js'
-import { type AbortEventData, type AbortRequestType, type FinalizeEventData, type MorticeEvents, type RequestEventData, type RequestType } from '../mortice.js'
-import { type TypedEventTarget } from 'main-event'
+import type { AbortEventData, AbortRequestType, FinalizeEventData, MorticeEvents, RequestType } from '../mortice.js'
+import type { TypedEventTarget } from 'main-event'
 
 export const handleChannelWorkerLockRequest = (emitter: TypedEventTarget<MorticeEvents>, channel: BroadcastChannel, masterEvent: RequestType, abortMasterEvent: AbortRequestType, requestType: string, abortType: string, errorType: string, releaseType: string, grantType: string) => {
   return (event: MessageEvent) => {

--- a/src/main/channel.ts
+++ b/src/main/channel.ts
@@ -1,0 +1,91 @@
+import {
+  WORKER_FINALIZE
+} from '../constants.js'
+import { type AbortEventData, type AbortRequestType, type FinalizeEventData, type MorticeEvents, type RequestEventData, type RequestType } from '../mortice.js'
+import { type TypedEventTarget } from 'main-event'
+
+export const handleChannelWorkerLockRequest = (emitter: TypedEventTarget<MorticeEvents>, channel: BroadcastChannel, masterEvent: RequestType, abortMasterEvent: AbortRequestType, requestType: string, abortType: string, errorType: string, releaseType: string, grantType: string) => {
+  return (event: MessageEvent) => {
+    if (event.data == null) {
+      return
+    }
+
+    const requestEvent = {
+      type: event.data.type,
+      name: event.data.name,
+      identifier: event.data.identifier
+    }
+
+    // worker is requesting lock
+    if (requestEvent.type === requestType) {
+      emitter.safeDispatchEvent(masterEvent, {
+        detail: {
+          name: requestEvent.name,
+          identifier: requestEvent.identifier,
+          handler: async (): Promise<void> => {
+            // grant lock to worker
+            channel.postMessage({
+              type: grantType,
+              name: requestEvent.name,
+              identifier: requestEvent.identifier
+            })
+
+            // wait for worker to finish
+            await new Promise<void>((resolve) => {
+              const releaseEventListener = (event: MessageEvent): void => {
+                if (event?.data == null) {
+                  return
+                }
+
+                const releaseEvent = {
+                  type: event.data.type,
+                  name: event.data.name,
+                  identifier: event.data.identifier
+                }
+
+                if (releaseEvent.type === releaseType && releaseEvent.identifier === requestEvent.identifier) {
+                  channel.removeEventListener('message', releaseEventListener)
+                  resolve()
+                }
+              }
+
+              channel.addEventListener('message', releaseEventListener)
+            })
+          },
+          onError: (err: Error) => {
+            // send error to worker
+            channel.postMessage({
+              type: errorType,
+              name: requestEvent.name,
+              identifier: requestEvent.identifier,
+              error: {
+                message: err.message,
+                name: err.name,
+                stack: err.stack
+              }
+            })
+          }
+        }
+      })
+    }
+
+    // worker is no longer interested in requesting the lock
+    if (requestEvent.type === abortType) {
+      emitter.safeDispatchEvent<AbortEventData>(abortMasterEvent, {
+        detail: {
+          name: requestEvent.name,
+          identifier: requestEvent.identifier
+        }
+      })
+    }
+
+    // worker is done with lock
+    if (requestEvent.type === WORKER_FINALIZE) {
+      emitter.safeDispatchEvent<FinalizeEventData>('finalizeRequest', {
+        detail: {
+          name: requestEvent.name
+        }
+      })
+    }
+  }
+}

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -1,0 +1,76 @@
+import {
+  WORKER_FINALIZE
+} from '../constants.js'
+import type { AbortEventData, AbortRequestType, FinalizeEventData, MorticeEvents, RequestEvent, RequestEventData, RequestType } from '../mortice.js'
+import type { Worker } from 'node:cluster'
+import type { TypedEventTarget } from 'main-event'
+
+export const handleClusterWorkerLockRequest = (emitter: TypedEventTarget<MorticeEvents>, masterEvent: RequestType, abortMasterEvent: AbortRequestType, requestType: string, abortType: string, errorType: string, releaseType: string, grantType: string) => {
+  return (worker: Worker, requestEvent: RequestEvent) => {
+    if (requestEvent == null) {
+      return
+    }
+
+    // worker is requesting lock
+    if (requestEvent.type === requestType) {
+      emitter.safeDispatchEvent<RequestEventData>(masterEvent, {
+        detail: {
+          name: requestEvent.name,
+          identifier: requestEvent.identifier,
+          handler: async () => {
+            // grant lock to worker
+            worker.send({
+              type: grantType,
+              name: requestEvent.name,
+              identifier: requestEvent.identifier
+            })
+
+            // wait for worker to finish
+            await new Promise<void>((resolve) => {
+              const releaseEventListener = (releaseEvent: RequestEvent): void => {
+                if (releaseEvent.type === releaseType && releaseEvent.identifier === requestEvent.identifier) {
+                  worker.removeListener('message', releaseEventListener)
+                  resolve()
+                }
+              }
+
+              worker.on('message', releaseEventListener)
+            })
+          },
+          onError: (err: Error) => {
+            // send error to worker
+            worker.send({
+              type: errorType,
+              name: requestEvent.name,
+              identifier: requestEvent.identifier,
+              error: {
+                message: err.message,
+                name: err.name,
+                stack: err.stack
+              }
+            })
+          }
+        }
+      })
+    }
+
+    // worker is no longer interested in requesting the lock
+    if (requestEvent.type === abortType) {
+      emitter.safeDispatchEvent<AbortEventData>(abortMasterEvent, {
+        detail: {
+          name: requestEvent.name,
+          identifier: requestEvent.identifier
+        }
+      })
+    }
+
+    // worker is done with lock
+    if (requestEvent.type === WORKER_FINALIZE) {
+      emitter.safeDispatchEvent<FinalizeEventData>('finalizeRequest', {
+        detail: {
+          name: requestEvent.name
+        }
+      })
+    }
+  }
+}

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -2,8 +2,8 @@ import {
   WORKER_FINALIZE
 } from '../constants.js'
 import type { AbortEventData, AbortRequestType, FinalizeEventData, MorticeEvents, RequestEvent, RequestEventData, RequestType } from '../mortice.js'
-import type { Worker } from 'node:cluster'
 import type { TypedEventTarget } from 'main-event'
+import type { Worker } from 'node:cluster'
 
 export const handleClusterWorkerLockRequest = (emitter: TypedEventTarget<MorticeEvents>, masterEvent: RequestType, abortMasterEvent: AbortRequestType, requestType: string, abortType: string, errorType: string, releaseType: string, grantType: string) => {
   return (worker: Worker, requestEvent: RequestEvent) => {

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,4 +1,5 @@
-import cluster from 'cluster'
+import cluster from 'node:cluster'
+import worker from 'node:worker_threads'
 import { TypedEventEmitter } from 'main-event'
 import {
   WORKER_REQUEST_READ_LOCK,
@@ -11,212 +12,36 @@ import {
   WORKER_ABORT_WRITE_LOCK_REQUEST,
   MASTER_READ_LOCK_ERROR,
   MASTER_WRITE_LOCK_ERROR,
-  WORKER_FINALIZE
+  BROADCAST_CHANNEL_NAME,
+  defaultOptions
 } from './constants.js'
-import { nanoid } from './utils.js'
-import type { Mortice, MorticeOptions, Release } from './index.js'
-import type { AbortEventData, AbortRequestType, FinalizeEventData, MorticeEvents, RequestEventData, RequestType } from './mortice.js'
-import type { AbortOptions } from 'abort-error'
-import type { Worker } from 'cluster'
+import type { Mortice, MorticeOptions } from './index.js'
+import type { MorticeEvents } from './mortice.js'
 import type { TypedEventTarget } from 'main-event'
+import { handleClusterWorkerLockRequest } from './main/cluster.ts'
+import { handleChannelWorkerLockRequest } from './main/channel.ts'
+import { MorticeClusterWorker } from './workers/cluster.ts'
+import { MorticeChannelWorker } from './workers/channel.ts'
 
-interface RequestEvent {
-  type: string
-  identifier: string
-  name: string,
-  error?: {
-    name: string
-    message: string
-    stack: string
-  }
-}
-
-const handleWorkerLockRequest = (emitter: EventTarget, masterEvent: RequestType, abortMasterEvent: AbortRequestType, requestType: string, abortType: string, errorType: string, releaseType: string, grantType: string) => {
-  return (worker: Worker, requestEvent: RequestEvent) => {
-    if (requestEvent == null) {
-      return
-    }
-
-    // worker is requesting lock
-    if (requestEvent.type === requestType) {
-      emitter.dispatchEvent(new MessageEvent<RequestEventData>(masterEvent, {
-        data: {
-          name: requestEvent.name,
-          identifier: requestEvent.identifier,
-          handler: async () => {
-            // grant lock to worker
-            worker.send({
-              type: grantType,
-              name: requestEvent.name,
-              identifier: requestEvent.identifier
-            })
-
-            // wait for worker to finish
-            await new Promise<void>((resolve) => {
-              const releaseEventListener = (releaseEvent: RequestEvent): void => {
-                if (releaseEvent.type === releaseType && releaseEvent.identifier === requestEvent.identifier) {
-                  worker.removeListener('message', releaseEventListener)
-                  resolve()
-                }
-              }
-
-              worker.on('message', releaseEventListener)
-            })
-          },
-          onError: (err: Error) => {
-            // send error to worker
-            worker.send({
-              type: errorType,
-              name: requestEvent.name,
-              identifier: requestEvent.identifier,
-              error: {
-                message: err.message,
-                name: err.name,
-                stack: err.stack
-              }
-            })
-          }
-        }
-      }))
-    }
-
-    // worker is no longer interested in requesting the lock
-    if (requestEvent.type === abortType) {
-      emitter.dispatchEvent(new MessageEvent<AbortEventData>(abortMasterEvent, {
-        data: {
-          name: requestEvent.name,
-          identifier: requestEvent.identifier
-        }
-      }))
-    }
-
-    // worker is done with lock
-    if (requestEvent.type === WORKER_FINALIZE) {
-      emitter.dispatchEvent(new MessageEvent<FinalizeEventData>('finalizeRequest', {
-        data: {
-          name: requestEvent.name
-        }
-      }))
-    }
-  }
-}
-
-class MorticeWorker implements Mortice {
-  private name: string
-
-  constructor (name: string) {
-    this.name = name
+function isMain () {
+  if (worker.isMainThread === false) {
+    return false
   }
 
-  readLock (options?: AbortOptions): Promise<Release> {
-    return this.sendRequest(
-      WORKER_REQUEST_READ_LOCK,
-      WORKER_ABORT_READ_LOCK_REQUEST,
-      MASTER_GRANT_READ_LOCK,
-      MASTER_READ_LOCK_ERROR,
-      WORKER_RELEASE_READ_LOCK,
-      options
-    )
+  if (worker.isInternalThread === true) {
+    return false
   }
 
-  writeLock (options?: AbortOptions): Promise<Release> {
-    return this.sendRequest(
-      WORKER_REQUEST_WRITE_LOCK,
-      WORKER_ABORT_WRITE_LOCK_REQUEST,
-      MASTER_GRANT_WRITE_LOCK,
-      MASTER_WRITE_LOCK_ERROR,
-      WORKER_RELEASE_WRITE_LOCK,
-      options
-    )
-  }
-
-  finalize (): void {
-    if (process.send == null) {
-      throw new Error('No send method on process - are we a cluster worker?')
-    }
-
-    process.send({
-      type: WORKER_FINALIZE,
-      identifier: nanoid(),
-      name: this.name
-    })
-  }
-
-  private async sendRequest (requestType: string, abortType: string, grantType: string, errorType: string, releaseType: string, options?: AbortOptions): Promise<Release> {
-    options?.signal?.throwIfAborted()
-
-    const id = nanoid()
-
-    if (process.send == null) {
-      throw new Error('No send method on process - are we a cluster worker?')
-    }
-
-    process.send({
-      type: requestType,
-      identifier: id,
-      name: this.name
-    })
-
-    return new Promise<Release>((resolve, reject) => {
-      const abortListener = (): void => {
-        process.send?.({
-          type: abortType,
-          identifier: id,
-          name: this.name
-        })
-      }
-
-      options?.signal?.addEventListener('abort', abortListener, {
-        once: true
-      })
-
-      const listener = (event: RequestEvent): void => {
-        if (event.identifier !== id) {
-          return
-        }
-
-        if (event.type === grantType) {
-          process.removeListener('message', listener)
-          options?.signal?.removeEventListener('abort', abortListener)
-
-          // lock granted
-          resolve(() => {
-            // release lock
-            process.send?.({
-              type: releaseType,
-              identifier: id,
-              name: this.name
-            })
-          })
-        }
-
-        if (event.type === errorType) {
-          process.removeListener('message', listener)
-          options?.signal?.removeEventListener('abort', abortListener)
-
-          // error while waiting for grant of lock
-          const err = new Error()
-
-          if (event.error != null) {
-            err.message = event.error.message
-            err.name = event.error.name
-            err.stack = event.error.stack
-          }
-
-          reject(err)
-        }
-      }
-
-      process.on('message', listener)
-    })
-  }
+  return cluster.isPrimary
 }
 
 export default (options: Required<MorticeOptions>): Mortice | TypedEventTarget<MorticeEvents> => {
-  if (cluster.isPrimary || options.singleProcess) {
+  options = Object.assign({}, defaultOptions, options)
+
+  if (isMain() || options.singleProcess) {
     const emitter = new TypedEventEmitter()
 
-    cluster.on('message', handleWorkerLockRequest(
+    cluster.on('message', handleClusterWorkerLockRequest(
       emitter,
       'requestReadLock',
       'abortReadLockRequest',
@@ -226,7 +51,7 @@ export default (options: Required<MorticeOptions>): Mortice | TypedEventTarget<M
       WORKER_RELEASE_READ_LOCK,
       MASTER_GRANT_READ_LOCK
     ))
-    cluster.on('message', handleWorkerLockRequest(
+    cluster.on('message', handleClusterWorkerLockRequest(
       emitter,
       'requestWriteLock',
       'abortWriteLockRequest',
@@ -237,8 +62,43 @@ export default (options: Required<MorticeOptions>): Mortice | TypedEventTarget<M
       MASTER_GRANT_WRITE_LOCK
     ))
 
+    const channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME)
+    channel.addEventListener('message', handleChannelWorkerLockRequest(
+      emitter,
+      channel,
+      'requestReadLock',
+      'abortReadLockRequest',
+      WORKER_REQUEST_READ_LOCK,
+      WORKER_ABORT_READ_LOCK_REQUEST,
+      MASTER_READ_LOCK_ERROR,
+      WORKER_RELEASE_READ_LOCK,
+      MASTER_GRANT_READ_LOCK
+    ))
+    channel.addEventListener('message', handleChannelWorkerLockRequest(
+      emitter,
+      channel,
+      'requestWriteLock',
+      'abortWriteLockRequest',
+      WORKER_REQUEST_WRITE_LOCK,
+      WORKER_ABORT_WRITE_LOCK_REQUEST,
+      MASTER_WRITE_LOCK_ERROR,
+      WORKER_RELEASE_WRITE_LOCK,
+      MASTER_GRANT_WRITE_LOCK
+    ))
+
+    // @ts-expect-error not in types
+    channel.unref?.()
+
     return emitter
   }
 
-  return new MorticeWorker(options.name)
+  if (cluster.isWorker) {
+    return new MorticeClusterWorker(options.name)
+  }
+
+  if (worker.isMainThread === false) {
+    return new MorticeChannelWorker(options.name)
+  }
+
+  throw new Error('Not a cluster worker or worker thread')
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -15,15 +15,15 @@ import {
   BROADCAST_CHANNEL_NAME,
   defaultOptions
 } from './constants.js'
+import { handleChannelWorkerLockRequest } from './main/channel.ts'
+import { handleClusterWorkerLockRequest } from './main/cluster.ts'
+import { MorticeChannelWorker } from './workers/channel.ts'
+import { MorticeClusterWorker } from './workers/cluster.ts'
 import type { Mortice, MorticeOptions } from './index.js'
 import type { MorticeEvents } from './mortice.js'
 import type { TypedEventTarget } from 'main-event'
-import { handleClusterWorkerLockRequest } from './main/cluster.ts'
-import { handleChannelWorkerLockRequest } from './main/channel.ts'
-import { MorticeClusterWorker } from './workers/cluster.ts'
-import { MorticeChannelWorker } from './workers/channel.ts'
 
-function isMain () {
+function isMain (): boolean {
   if (worker.isMainThread === false) {
     return false
   }

--- a/src/workers/channel.ts
+++ b/src/workers/channel.ts
@@ -1,0 +1,122 @@
+import {
+  WORKER_REQUEST_READ_LOCK,
+  WORKER_RELEASE_READ_LOCK,
+  MASTER_GRANT_READ_LOCK,
+  WORKER_REQUEST_WRITE_LOCK,
+  WORKER_RELEASE_WRITE_LOCK,
+  MASTER_GRANT_WRITE_LOCK,
+  WORKER_ABORT_READ_LOCK_REQUEST,
+  WORKER_ABORT_WRITE_LOCK_REQUEST,
+  MASTER_READ_LOCK_ERROR,
+  MASTER_WRITE_LOCK_ERROR,
+  WORKER_FINALIZE,
+  BROADCAST_CHANNEL_NAME
+} from '../constants.js'
+import { nanoid } from '../utils.js'
+import type { Mortice, Release } from '../index.js'
+import type { AbortOptions } from 'abort-error'
+
+export class MorticeChannelWorker implements Mortice {
+  private name: string
+  private channel: BroadcastChannel
+
+  constructor (name: string) {
+    this.name = name
+    this.channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME)
+  }
+
+  readLock (options?: AbortOptions): Promise<Release> {
+    return this.sendRequest(
+      WORKER_REQUEST_READ_LOCK,
+      WORKER_ABORT_READ_LOCK_REQUEST,
+      MASTER_GRANT_READ_LOCK,
+      MASTER_READ_LOCK_ERROR,
+      WORKER_RELEASE_READ_LOCK,
+      options
+    )
+  }
+
+  writeLock (options?: AbortOptions): Promise<Release> {
+    return this.sendRequest(
+      WORKER_REQUEST_WRITE_LOCK,
+      WORKER_ABORT_WRITE_LOCK_REQUEST,
+      MASTER_GRANT_WRITE_LOCK,
+      MASTER_WRITE_LOCK_ERROR,
+      WORKER_RELEASE_WRITE_LOCK,
+      options
+    )
+  }
+
+  finalize (): void {
+    this.channel.postMessage({
+      type: WORKER_FINALIZE,
+      name: this.name
+    })
+
+    this.channel.close()
+  }
+
+  private async sendRequest (requestType: string, abortType: string, grantType: string, errorType: string, releaseType: string, options?: AbortOptions): Promise<Release> {
+    options?.signal?.throwIfAborted()
+    const id = nanoid()
+
+    this.channel.postMessage({
+      type: requestType,
+      identifier: id,
+      name: this.name
+    })
+
+    return new Promise<Release>((resolve, reject) => {
+      const abortListener = (): void => {
+        this.channel.postMessage({
+          type: abortType,
+          identifier: id,
+          name: this.name
+        })
+      }
+
+      options?.signal?.addEventListener('abort', abortListener, {
+        once: true
+      })
+
+      const listener = (event: MessageEvent): void => {
+        if (event.data?.identifier !== id) {
+          return
+        }
+
+        if (event.data?.type === grantType) {
+          this.channel.removeEventListener('message', listener)
+          options?.signal?.removeEventListener('abort', abortListener)
+
+          // lock granted
+          resolve(() => {
+            // release lock
+            this.channel.postMessage({
+              type: releaseType,
+              identifier: id,
+              name: this.name
+            })
+          })
+        }
+
+        if (event.data.type === errorType) {
+          this.channel.removeEventListener('message', listener)
+          options?.signal?.removeEventListener('abort', abortListener)
+
+          // error while waiting for grant of lock
+          const err = new Error()
+
+          if (event.data.error != null) {
+            err.message = event.data.error.message
+            err.name = event.data.error.name
+            err.stack = event.data.error.stack
+          }
+
+          reject(err)
+        }
+      }
+
+      this.channel.addEventListener('message', listener)
+    })
+  }
+}

--- a/src/workers/cluster.ts
+++ b/src/workers/cluster.ts
@@ -13,8 +13,8 @@ import {
 } from '../constants.js'
 import { nanoid } from '../utils.js'
 import type { Mortice, Release } from '../index.js'
-import type { AbortOptions } from 'abort-error'
 import type { RequestEvent } from '../mortice.ts'
+import type { AbortOptions } from 'abort-error'
 
 export class MorticeClusterWorker implements Mortice {
   private name: string

--- a/src/workers/cluster.ts
+++ b/src/workers/cluster.ts
@@ -1,0 +1,128 @@
+import {
+  WORKER_REQUEST_READ_LOCK,
+  WORKER_RELEASE_READ_LOCK,
+  MASTER_GRANT_READ_LOCK,
+  WORKER_REQUEST_WRITE_LOCK,
+  WORKER_RELEASE_WRITE_LOCK,
+  MASTER_GRANT_WRITE_LOCK,
+  WORKER_ABORT_READ_LOCK_REQUEST,
+  WORKER_ABORT_WRITE_LOCK_REQUEST,
+  MASTER_READ_LOCK_ERROR,
+  MASTER_WRITE_LOCK_ERROR,
+  WORKER_FINALIZE
+} from '../constants.js'
+import { nanoid } from '../utils.js'
+import type { Mortice, Release } from '../index.js'
+import type { AbortOptions } from 'abort-error'
+import type { RequestEvent } from '../mortice.ts'
+
+export class MorticeClusterWorker implements Mortice {
+  private name: string
+
+  constructor (name: string) {
+    this.name = name
+  }
+
+  readLock (options?: AbortOptions): Promise<Release> {
+    return this.sendRequest(
+      WORKER_REQUEST_READ_LOCK,
+      WORKER_ABORT_READ_LOCK_REQUEST,
+      MASTER_GRANT_READ_LOCK,
+      MASTER_READ_LOCK_ERROR,
+      WORKER_RELEASE_READ_LOCK,
+      options
+    )
+  }
+
+  writeLock (options?: AbortOptions): Promise<Release> {
+    return this.sendRequest(
+      WORKER_REQUEST_WRITE_LOCK,
+      WORKER_ABORT_WRITE_LOCK_REQUEST,
+      MASTER_GRANT_WRITE_LOCK,
+      MASTER_WRITE_LOCK_ERROR,
+      WORKER_RELEASE_WRITE_LOCK,
+      options
+    )
+  }
+
+  finalize (): void {
+    if (process.send == null) {
+      throw new Error('No send method on process - are we a cluster worker?')
+    }
+
+    process.send({
+      type: WORKER_FINALIZE,
+      identifier: nanoid(),
+      name: this.name
+    })
+  }
+
+  private async sendRequest (requestType: string, abortType: string, grantType: string, errorType: string, releaseType: string, options?: AbortOptions): Promise<Release> {
+    options?.signal?.throwIfAborted()
+
+    const id = nanoid()
+
+    if (process.send == null) {
+      throw new Error('No send method on process - are we a cluster worker?')
+    }
+
+    process.send({
+      type: requestType,
+      identifier: id,
+      name: this.name
+    })
+
+    return new Promise<Release>((resolve, reject) => {
+      const abortListener = (): void => {
+        process.send?.({
+          type: abortType,
+          identifier: id,
+          name: this.name
+        })
+      }
+
+      options?.signal?.addEventListener('abort', abortListener, {
+        once: true
+      })
+
+      const listener = (event: RequestEvent): void => {
+        if (event.identifier !== id) {
+          return
+        }
+
+        if (event.type === grantType) {
+          process.removeListener('message', listener)
+          options?.signal?.removeEventListener('abort', abortListener)
+
+          // lock granted
+          resolve(() => {
+            // release lock
+            process.send?.({
+              type: releaseType,
+              identifier: id,
+              name: this.name
+            })
+          })
+        }
+
+        if (event.type === errorType) {
+          process.removeListener('message', listener)
+          options?.signal?.removeEventListener('abort', abortListener)
+
+          // error while waiting for grant of lock
+          const err = new Error()
+
+          if (event.error != null) {
+            err.message = event.error.message
+            err.name = event.error.name
+            err.stack = event.error.stack
+          }
+
+          reject(err)
+        }
+      }
+
+      process.on('message', listener)
+    })
+  }
+}

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -33,6 +33,7 @@ describe('cluster', () => {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -61,6 +62,7 @@ describe('cluster', () => {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -80,9 +82,11 @@ describe('cluster', () => {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
+      'write 1 delay 500ms',
       'write 2 error The operation was aborted',
       'write 1 complete',
       'write 3 start',
+      'write 3 delay 500ms',
       'write 3 complete'
     ])
   })
@@ -98,10 +102,13 @@ describe('cluster', () => {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
+      'write 1 delay 500ms',
       'write 1 complete',
       'write 2 start',
+      'write 2 delay 500ms',
       'write 2 complete',
       'write 3 start',
+      'write 3 delay 500ms',
       'write 3 complete',
       'write 3 finalize'
     ])

--- a/test/fixtures/cluster-abort.ts
+++ b/test/fixtures/cluster-abort.ts
@@ -1,4 +1,4 @@
-import cluster from 'cluster'
+import cluster from 'node:cluster'
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
 

--- a/test/fixtures/cluster-single-thread.ts
+++ b/test/fixtures/cluster-single-thread.ts
@@ -1,4 +1,4 @@
-import cluster from 'cluster'
+import cluster from 'node:cluster'
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
 

--- a/test/fixtures/cluster.ts
+++ b/test/fixtures/cluster.ts
@@ -1,4 +1,4 @@
-import cluster from 'cluster'
+import cluster from 'node:cluster'
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
 

--- a/test/fixtures/lock.ts
+++ b/test/fixtures/lock.ts
@@ -34,6 +34,7 @@ export async function lock (type: 'read' | 'write', mutex: Mortice, counts: Coun
     if (options.finalize === true) {
       mutex.finalize()
       result.push(`${type} ${index} finalize`)
+      await delay(10)
     }
   } catch (err: any) {
     result.push(`${type} ${index} error ${err.message}`)

--- a/test/fixtures/lock.ts
+++ b/test/fixtures/lock.ts
@@ -24,6 +24,7 @@ export async function lock (type: 'read' | 'write', mutex: Mortice, counts: Coun
     result.push(`${type} ${index} start`)
 
     if (options.timeout != null && options.timeout > 0) {
+      result.push(`${type} ${index} delay ${options.timeout}ms`)
       await delay(options.timeout)
     }
 

--- a/test/fixtures/worker-abort.ts
+++ b/test/fixtures/worker-abort.ts
@@ -1,3 +1,4 @@
+import delay from 'delay'
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
 import { postMessage } from './worker-post-message.js'
@@ -25,6 +26,8 @@ async function run (): Promise<string[]> {
       timeout: 500
     })
   ]
+
+  await delay(100)
 
   controller.abort()
 

--- a/test/fixtures/worker-abort.ts
+++ b/test/fixtures/worker-abort.ts
@@ -1,5 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
+import { postMessage } from './worker-post-message.ts'
 
 async function run (): Promise<string[]> {
   const mutex = mortice()
@@ -33,12 +34,12 @@ async function run (): Promise<string[]> {
 }
 
 run().then((result: string[] = []) => {
-  globalThis.postMessage({
+  postMessage({
     type: 'done',
     result
   })
 }, err => {
-  globalThis.postMessage({
+  postMessage({
     type: 'error',
     error: {
       message: err.message,

--- a/test/fixtures/worker-abort.ts
+++ b/test/fixtures/worker-abort.ts
@@ -16,7 +16,7 @@ async function run (): Promise<string[]> {
   // queue up requests, the second should abort and the third should continue
   const p = [
     lock('write', mutex, counts, result, {
-      timeout: 500
+      timeout: 2_000
     }),
     lock('write', mutex, counts, result, {
       timeout: 500,
@@ -29,7 +29,7 @@ async function run (): Promise<string[]> {
 
   // wait for first write to delay, then abort controller
   while (true) {
-    if (result.includes('write 1 delay 500ms')) {
+    if (result.includes('write 1 delay 2000ms')) {
       controller.abort()
       break
     }

--- a/test/fixtures/worker-abort.ts
+++ b/test/fixtures/worker-abort.ts
@@ -1,6 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
-import { postMessage } from './worker-post-message.ts'
+import { postMessage } from './worker-post-message.js'
 
 async function run (): Promise<string[]> {
   const mutex = mortice()

--- a/test/fixtures/worker-abort.ts
+++ b/test/fixtures/worker-abort.ts
@@ -27,9 +27,9 @@ async function run (): Promise<string[]> {
     })
   ]
 
-  // wait for first write to start, then abort controller
+  // wait for first write to delay, then abort controller
   while (true) {
-    if (result.includes('write 1 start')) {
+    if (result.includes('write 1 delay 500ms')) {
       controller.abort()
       break
     }

--- a/test/fixtures/worker-abort.ts
+++ b/test/fixtures/worker-abort.ts
@@ -27,9 +27,15 @@ async function run (): Promise<string[]> {
     })
   ]
 
-  await delay(100)
+  // wait for first write to start, then abort controller
+  while (true) {
+    if (result.includes('write 1 start')) {
+      controller.abort()
+      break
+    }
 
-  controller.abort()
+    await delay(10)
+  }
 
   await Promise.all(p)
 

--- a/test/fixtures/worker-finalize.ts
+++ b/test/fixtures/worker-finalize.ts
@@ -1,5 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
+import { postMessage } from './worker-post-message.ts'
 
 async function run (): Promise<string[]> {
   const mutex = mortice()
@@ -33,12 +34,12 @@ async function run (): Promise<string[]> {
 }
 
 run().then((result: string[] = []) => {
-  globalThis.postMessage({
+  postMessage({
     type: 'done',
     result
   })
 }, err => {
-  globalThis.postMessage({
+  postMessage({
     type: 'error',
     error: {
       message: err.message,

--- a/test/fixtures/worker-finalize.ts
+++ b/test/fixtures/worker-finalize.ts
@@ -1,6 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
-import { postMessage } from './worker-post-message.ts'
+import { postMessage } from './worker-post-message.js'
 
 async function run (): Promise<string[]> {
   const mutex = mortice()

--- a/test/fixtures/worker-post-message.browser.ts
+++ b/test/fixtures/worker-post-message.browser.ts
@@ -1,3 +1,3 @@
-export function postMessage (val: any) {
+export function postMessage (val: any): void {
   globalThis.postMessage(val)
 }

--- a/test/fixtures/worker-post-message.browser.ts
+++ b/test/fixtures/worker-post-message.browser.ts
@@ -1,0 +1,3 @@
+export function postMessage (val: any) {
+  globalThis.postMessage(val)
+}

--- a/test/fixtures/worker-post-message.ts
+++ b/test/fixtures/worker-post-message.ts
@@ -1,0 +1,5 @@
+import worker from 'node:worker_threads'
+
+export function postMessage (val: any) {
+  worker.parentPort?.postMessage(val)
+}

--- a/test/fixtures/worker-post-message.ts
+++ b/test/fixtures/worker-post-message.ts
@@ -1,5 +1,5 @@
 import worker from 'node:worker_threads'
 
-export function postMessage (val: any) {
+export function postMessage (val: any): void {
   worker.parentPort?.postMessage(val)
 }

--- a/test/fixtures/worker-single-thread.ts
+++ b/test/fixtures/worker-single-thread.ts
@@ -1,6 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
-import { postMessage } from './worker-post-message.ts'
+import { postMessage } from './worker-post-message.js'
 
 async function run (): Promise<string[]> {
   const mutex = mortice({

--- a/test/fixtures/worker-single-thread.ts
+++ b/test/fixtures/worker-single-thread.ts
@@ -1,5 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
+import { postMessage } from './worker-post-message.ts'
 
 async function run (): Promise<string[]> {
   const mutex = mortice({
@@ -24,12 +25,12 @@ async function run (): Promise<string[]> {
 }
 
 run().then((result: string[] = []) => {
-  globalThis.postMessage({
+  postMessage({
     type: 'done',
     result
   })
 }, err => {
-  globalThis.postMessage({
+  postMessage({
     type: 'error',
     error: {
       message: err.message,

--- a/test/fixtures/worker.ts
+++ b/test/fixtures/worker.ts
@@ -1,6 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
-import { postMessage } from './worker-post-message.ts'
+import { postMessage } from './worker-post-message.js'
 
 async function run (): Promise<string[]> {
   const mutex = mortice()

--- a/test/fixtures/worker.ts
+++ b/test/fixtures/worker.ts
@@ -1,5 +1,6 @@
 import mortice from '../../src/index.js'
 import { lock } from './lock.js'
+import { postMessage } from './worker-post-message.ts'
 
 async function run (): Promise<string[]> {
   const mutex = mortice()
@@ -22,12 +23,12 @@ async function run (): Promise<string[]> {
 }
 
 run().then((result: string[] = []) => {
-  globalThis.postMessage({
+  postMessage({
     type: 'done',
     result
   })
 }, err => {
-  globalThis.postMessage({
+  postMessage({
     type: 'error',
     error: {
       message: err.message,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -71,6 +71,7 @@ describe('mortice', () => {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -97,6 +98,7 @@ describe('mortice', () => {
       'read 1 waiting',
       'write 1 waiting',
       'read 1 start',
+      'read 1 delay 500ms',
       'read 1 complete',
       'write 1 start',
       'write 1 complete'

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,2 +1,3 @@
 import './index.test.js'
 import './cluster.test.js'
+import './worker-threads.test.js'

--- a/test/webworkers.test.ts
+++ b/test/webworkers.test.ts
@@ -123,7 +123,7 @@ describe('webworkers', function () {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
-      'write 1 delay 500ms',
+      'write 1 delay 2000ms',
       'write 2 error The operation was aborted',
       'write 1 complete',
       'write 3 start',

--- a/test/webworkers.test.ts
+++ b/test/webworkers.test.ts
@@ -115,7 +115,7 @@ describe('webworkers', function () {
     ])
   })
 
-  it('aborts a lock across a cluster', async () => {
+  it('aborts a lock across workers', async () => {
     await expect(runWorker('dist/worker-abort.js')).to.eventually.deep.equal([
       'write 1 waiting',
       'write 2 waiting',

--- a/test/webworkers.test.ts
+++ b/test/webworkers.test.ts
@@ -84,6 +84,7 @@ describe('webworkers', function () {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -107,6 +108,7 @@ describe('webworkers', function () {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -121,9 +123,11 @@ describe('webworkers', function () {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
+      'write 1 delay 500ms',
       'write 2 error The operation was aborted',
       'write 1 complete',
       'write 3 start',
+      'write 3 delay 500ms',
       'write 3 complete'
     ])
   })
@@ -140,10 +144,13 @@ describe('webworkers', function () {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
+      'write 1 delay 500ms',
       'write 1 complete',
       'write 2 start',
+      'write 2 delay 500ms',
       'write 2 complete',
       'write 3 start',
+      'write 3 delay 500ms',
       'write 3 complete',
       'write 3 finalize'
     ])

--- a/test/worker-threads.test.ts
+++ b/test/worker-threads.test.ts
@@ -1,8 +1,8 @@
+import { Worker } from 'node:worker_threads'
 import { expect } from 'aegir/chai'
-import observe from 'observable-webworkers'
+import { isNode, isElectronMain } from 'wherearewe'
 import mortice from '../src/index.js'
 import type { Mortice } from '../src/index.js'
-import type { WebworkerEventListener } from 'observable-webworkers'
 
 interface ResultEvent {
   type: 'done'
@@ -23,39 +23,38 @@ type WorkerEvent = ResultEvent | LogEvent | ErrorEvent
 
 async function runWorker (path: string): Promise<string[]> {
   return new Promise<string[]>((resolve, reject) => {
-    const worker = new Worker(path, {
-      type: 'module'
-    })
-    observe(worker)
+    const worker = new Worker(path)
 
-    const messageListener: WebworkerEventListener<WorkerEvent> = (worker, event) => {
-      if (event.data.type === 'log') {
-        console.info(event.data.message) // eslint-disable-line no-console
+    worker.on('message', (event: WorkerEvent) => {
+      if (event.type === 'log') {
+        console.info(event.message) // eslint-disable-line no-console
       }
 
-      if (event.data.type === 'error') {
+      if (event.type === 'error') {
         worker.terminate()
 
-        const err = new Error(event.data.error.message)
-        err.stack = event.data.error.stack
+        const err = new Error(event.error.message)
+        err.stack = event.error.stack
 
         reject(err)
       }
 
-      if (event.data.type === 'done') {
+      if (event.type === 'done') {
         worker.terminate()
-
-        resolve(event.data.result)
+          .then(() => {
+            resolve(event.result)
+          })
+          .catch(err => {
+            reject(err)
+          })
       }
-    }
-
-    observe.addEventListener('message', messageListener)
+    })
   })
 }
 
-describe('webworkers', function () {
-  if (globalThis.Worker == null) {
-    return it.skip('No worker support in environment')
+describe('worker threads', function () {
+  if (!isNode && !isElectronMain) {
+    return it.skip('cluster tests only run on node')
   }
 
   // hold lock in main thread
@@ -70,7 +69,7 @@ describe('webworkers', function () {
   })
 
   it('execute locks in correct order', async () => {
-    await expect(runWorker('dist/worker.js')).to.eventually.deep.equal([
+    await expect(runWorker('./dist/test/fixtures/worker.js')).to.eventually.deep.equal([
       'write 1 waiting',
       'read 1 waiting',
       'read 2 waiting',
@@ -93,7 +92,7 @@ describe('webworkers', function () {
   })
 
   it('execute locks in correct order in a single thread', async () => {
-    await expect(runWorker('dist/worker-single-thread.js')).to.eventually.deep.equal([
+    await expect(runWorker('./dist/test/fixtures/worker-single-thread.js')).to.eventually.deep.equal([
       'write 1 waiting',
       'read 1 waiting',
       'read 2 waiting',
@@ -116,7 +115,7 @@ describe('webworkers', function () {
   })
 
   it('aborts a lock across a cluster', async () => {
-    await expect(runWorker('dist/worker-abort.js')).to.eventually.deep.equal([
+    await expect(runWorker('./dist/test/fixtures/worker-abort.js')).to.eventually.deep.equal([
       'write 1 waiting',
       'write 2 waiting',
       'write 3 waiting',
@@ -135,7 +134,7 @@ describe('webworkers', function () {
       throw new Error('Mutex was different')
     }
 
-    await expect(runWorker('dist/worker-finalize.js')).to.eventually.deep.equal([
+    await expect(runWorker('./dist/test/fixtures/worker-finalize.js')).to.eventually.deep.equal([
       'write 1 waiting',
       'write 2 waiting',
       'write 3 waiting',

--- a/test/worker-threads.test.ts
+++ b/test/worker-threads.test.ts
@@ -114,7 +114,7 @@ describe('worker threads', function () {
     ])
   })
 
-  it('aborts a lock across a cluster', async () => {
+  it('aborts a lock across worker threads', async () => {
     await expect(runWorker('./dist/test/fixtures/worker-abort.js')).to.eventually.deep.equal([
       'write 1 waiting',
       'write 2 waiting',
@@ -127,7 +127,7 @@ describe('worker threads', function () {
     ])
   })
 
-  it('finalizes a lock across workers', async () => {
+  it('finalizes a lock across worker threads', async () => {
     const mutex2 = mortice()
 
     if (mutex !== mutex2) {

--- a/test/worker-threads.test.ts
+++ b/test/worker-threads.test.ts
@@ -122,7 +122,7 @@ describe('worker threads', function () {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
-      'write 1 delay 500ms',
+      'write 1 delay 2000ms',
       'write 2 error The operation was aborted',
       'write 1 complete',
       'write 3 start',

--- a/test/worker-threads.test.ts
+++ b/test/worker-threads.test.ts
@@ -83,6 +83,7 @@ describe('worker threads', function () {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -106,6 +107,7 @@ describe('worker threads', function () {
       'read 2 start',
       'read 2 complete',
       'read 3 start',
+      'read 3 delay 500ms',
       'read 3 complete',
       'write 2 start',
       'write 2 complete',
@@ -120,9 +122,11 @@ describe('worker threads', function () {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
+      'write 1 delay 500ms',
       'write 2 error The operation was aborted',
       'write 1 complete',
       'write 3 start',
+      'write 3 delay 500ms',
       'write 3 complete'
     ])
   })
@@ -139,10 +143,13 @@ describe('worker threads', function () {
       'write 2 waiting',
       'write 3 waiting',
       'write 1 start',
+      'write 1 delay 500ms',
       'write 1 complete',
       'write 2 start',
+      'write 2 delay 500ms',
       'write 2 complete',
       'write 3 start',
+      'write 3 delay 500ms',
       'write 3 complete',
       'write 3 finalize'
     ])


### PR DESCRIPTION
To support service workers, use BroadcastChannels where available instead of postMessage.

Also supports BroadcastChannels in node worker threads. Attempts to auto detect work threads vs cluster workers where the BroadcastChannel API is not available.

Fixes #67