### PR TITLE
fix: react native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,5 +165,9 @@
     "./dist/src/node.js": "./dist/src/browser.js",
     "./src/node.js": "./src/browser.js",
     "./test/fixtures/worker-post-message.js": "./test/fixtures/worker-post-message.browser.js"
+  },
+  "react-native": {
+    "./dist/src/node.js": "./dist/src/react-native.js",
+    "./src/node.js": "./src/react-native.js"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,14 @@
  *
  * // mutex will be freed soon after
  * ```
+ *
+ * ## React native support
+ *
+ * This module should run on react native but it only supports single-process
+ * concurrency as it's not clear to the author (disclaimer - not a react native
+ * dev) what the officially supported process concurrency model is.
+ *
+ * Please open an issue if this is a feature you would like to see added.
  */
 
 import { Queue } from 'it-queue'

--- a/src/mortice.ts
+++ b/src/mortice.ts
@@ -194,6 +194,9 @@ export const createMutex = (name: string, options: Required<MorticeOptions>): Mo
 
   const implementation = getImplementation(options)
 
+  // a Mortice instance will be returned if we are a worker, otherwise if we are
+  // primary an event target will be returned that fires events when workers
+  // request a lock
   if (isMortice(implementation)) {
     mutex = implementation
 

--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -1,0 +1,9 @@
+import { TypedEventEmitter } from 'main-event'
+import type { Mortice, MorticeOptions } from './index.js'
+import type { MorticeEvents } from './mortice.js'
+import type { TypedEventTarget } from 'main-event'
+
+export default (options: Required<MorticeOptions>): Mortice | TypedEventTarget<MorticeEvents> => {
+  // react-native is single-process only
+  return new TypedEventEmitter()
+}


### PR DESCRIPTION
Make react native be single-process only.

I have no idea what the official concurrency model is. There are some userland modules with only a handful of downloads so if anyone knows more please open an issue.